### PR TITLE
Breaking change - Example 1

### DIFF
--- a/PactNETPlayground.Producer/Domain/MediaType.cs
+++ b/PactNETPlayground.Producer/Domain/MediaType.cs
@@ -1,0 +1,10 @@
+﻿namespace PactNETPlayground.Producer.Domain; 
+
+public enum MediaType {
+    
+    None = 0,
+    
+    Digital = 1,
+    
+    TV = 2
+}

--- a/PactNETPlayground.Producer/Features/Estimates/EstimatesController.cs
+++ b/PactNETPlayground.Producer/Features/Estimates/EstimatesController.cs
@@ -1,5 +1,6 @@
 ﻿using System.Security.Cryptography;
 using Microsoft.AspNetCore.Mvc;
+using PactNETPlayground.Producer.Domain;
 using PactNETPlayground.Producer.Features.Estimates.Models.Input;
 using PactNETPlayground.Producer.Features.Estimates.Models.Output;
 
@@ -20,7 +21,7 @@ public class EstimatesController : ControllerBase {
             Id = id,
             CustomerId = $"Customer-{id}",
             Date = DateTime.Now.AddDays(-((DateTime.Now.Second + 1) % 5)).Date,
-            MediaType = "Digital"
+            MediaType = MediaType.Digital
         }));
     }
     
@@ -46,7 +47,7 @@ public class EstimatesController : ControllerBase {
                     Id = id,
                     CustomerId = $"Customer-{id}",
                     Date = DateTime.Now.AddDays(-((DateTime.Now.Second + 1) % 5)).Date,
-                    MediaType = "Digital"
+                    MediaType = i % 2 == 0 ? MediaType.Digital : MediaType.TV
                 };
             });
         

--- a/PactNETPlayground.Producer/Features/Estimates/Models/Input/CreateEstimate.cs
+++ b/PactNETPlayground.Producer/Features/Estimates/Models/Input/CreateEstimate.cs
@@ -1,8 +1,10 @@
-﻿namespace PactNETPlayground.Producer.Features.Estimates.Models.Input; 
+﻿using PactNETPlayground.Producer.Domain;
+
+namespace PactNETPlayground.Producer.Features.Estimates.Models.Input; 
 
 public class CreateEstimate {
 
     public string CustomerId { get; set; } = null!;
 
-    public string MediaType { get; set; } = null!;
+    public MediaType MediaType { get; set; } 
 }

--- a/PactNETPlayground.Producer/Features/Estimates/Models/Output/Estimate.cs
+++ b/PactNETPlayground.Producer/Features/Estimates/Models/Output/Estimate.cs
@@ -1,4 +1,6 @@
-﻿namespace PactNETPlayground.Producer.Features.Estimates.Models.Output; 
+﻿using PactNETPlayground.Producer.Domain;
+
+namespace PactNETPlayground.Producer.Features.Estimates.Models.Output; 
 
 public class Estimate {
 
@@ -8,5 +10,5 @@ public class Estimate {
     
     public string CustomerId { get; set; } = null!;
 
-    public string MediaType { get; set; } = null!;
+    public MediaType MediaType { get; set; }
 }


### PR DESCRIPTION
We introduce `MediaType` enum type, and change the type of existing property `MediaType` in models.

Nothing is changes in `PactNETPlayground.Consumer`, so when we run tests, verification fails because the contract consumers are using is no longer valid. 

Sample output

```
Verifying a pact between PactNETPlayground.Consumer and PactNETPlayground.Provider

  A request to retrieve an estimate
    returns a response which
      has status code 200 (OK)
      includes headers
        "Content-Type" with value "application/json" (OK)
      has a matching body (FAILED)

  A request to create an estimate
    returns a response which
      has status code 201 (FAILED)
      includes headers
        "Content-Type" with value "application/json" (FAILED)
      has a matching body (FAILED)

  A request to search for estimates
    returns a response which
      has status code 200 (OK)
      includes headers
        "Content-Type" with value "application/json" (OK)
      has a matching body (FAILED)


Failures:

1) Verifying a pact between PactNETPlayground.Consumer and PactNETPlayground.Provider Given estimate with Id 54 exists - A request to retrieve an estimate
    1.1) has a matching body
           $.mediaType -> Expected 'Digital' to be the same type as '1'
2) Verifying a pact between PactNETPlayground.Consumer and PactNETPlayground.Provider Given payload is valid - A request to create an estimate
    2.1) has a matching body
           expected 'application/json' body but was 'application/problem+json;charset=utf-8'
    2.2) has status code 201
           expected 201 but was 400
    2.3) includes header 'Content-Type' with value 'application/json'
           Expected header 'Content-Type' to have value 'application/json' but was 'application/problem+json; charset=utf-8'
3) Verifying a pact between PactNETPlayground.Consumer and PactNETPlayground.Provider Given there are 5 estimates - A request to search for estimates
    3.1) has a matching body
           $[2].mediaType -> Expected 'Digital' to be the same type as '2'
           $[0].mediaType -> Expected 'Digital' to be the same type as '2'
           $[1].mediaType -> Expected 'Digital' to be the same type as '1'
           $[3].mediaType -> Expected 'Digital' to be the same type as '1'
           $[4].mediaType -> Expected 'Digital' to be the same type as '2'

There were 3 pact failures
```